### PR TITLE
fix: termination criterion of the algorithm

### DIFF
--- a/core/src/main/java/es/urjc/etsii/grafo/solver/algorithms/IteratedGreedy.java
+++ b/core/src/main/java/es/urjc/etsii/grafo/solver/algorithms/IteratedGreedy.java
@@ -70,6 +70,7 @@ public class IteratedGreedy<S extends Solution<I>, I extends Instance> extends A
                 iterationsWithoutImprovement++;
                 if(iterationsWithoutImprovement>=this.stopIfNotImprovedIn){
                     logger.fine(String.format("Not improved after %s iterations, stopping in iteration %s. Current score %s - %s", stopIfNotImprovedIn, i, solution.getScore(), solution));
+                    break;
                 }
             }
         }


### PR DESCRIPTION
The Iterated Greedy algorithm did not take into account the finalization criterion determined by the number of iterations without improvement. Corrections have been added to take this criterion into account. 