### PR TITLE
fix: line breaks removed

### DIFF
--- a/core/middleware.sh
+++ b/core/middleware.sh
@@ -19,7 +19,7 @@
 
 HOST=localhost
 PORT=8080
-CONFIG_PARAMS=$(echo -ne "$*" | base64)
+CONFIG_PARAMS=$(echo -ne "$*" | base64 | tr --delete "\n")
 
 curl -X POST --data "key=__INTEGRATION_KEY__&config=${CONFIG_PARAMS}" "http://${HOST}:${PORT}/api/execute"
 


### PR DESCRIPTION
Previously, when you tried to execute the irace, the request contained line breaks  and therefore, it was incorrect. This has been fixed by adding a new operation. 