### PR TITLE
added server port to application.yml

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -213,3 +213,6 @@ logging:
 
   # Logging format for console
   pattern.console: '%clr([%d{${LOG_DATEFORMAT_PATTERN:HH:mm:ss}}]){faint} %clr(${LOG_LEVEL_PATTERN:%3p}) %clr(%-26.26logger{25}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}'
+  
+server:
+    port : 8080

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -214,5 +214,6 @@ logging:
   # Logging format for console
   pattern.console: '%clr([%d{${LOG_DATEFORMAT_PATTERN:HH:mm:ss}}]){faint} %clr(${LOG_LEVEL_PATTERN:%3p}) %clr(%-26.26logger{25}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}'
   
+# Set default server port (change if there is multiple Mork instances running)
 server:
     port : 8080

--- a/example-tsp/src/main/resources/application.yml
+++ b/example-tsp/src/main/resources/application.yml
@@ -213,3 +213,6 @@ logging:
 
   # Logging format for console
   pattern.console: '%clr([%d{${LOG_DATEFORMAT_PATTERN:HH:mm:ss}}]){faint} %clr(${LOG_LEVEL_PATTERN:%3p}) %clr(%-26.26logger{25}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}'
+  
+server:
+    port : 8080

--- a/example-tsp/src/main/resources/application.yml
+++ b/example-tsp/src/main/resources/application.yml
@@ -214,5 +214,6 @@ logging:
   # Logging format for console
   pattern.console: '%clr([%d{${LOG_DATEFORMAT_PATTERN:HH:mm:ss}}]){faint} %clr(${LOG_LEVEL_PATTERN:%3p}) %clr(%-26.26logger{25}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}'
   
+# Set default server port (change if there is multiple Mork instances running)
 server:
     port : 8080

--- a/template/src/main/resources/application.yml
+++ b/template/src/main/resources/application.yml
@@ -220,3 +220,7 @@ logging:
   # Logging format for console and file
   pattern.console: '%clr([%d{${LOG_DATEFORMAT_PATTERN:HH:mm:ss}}]){faint} %clr(${LOG_LEVEL_PATTERN:%3p}) %clr(%-26.26logger{25}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}'
   pattern.file: '%clr([%d{${LOG_DATEFORMAT_PATTERN:HH:mm:ss}}]){faint} %clr(${LOG_LEVEL_PATTERN:%3p}) %clr(%-26.26logger{25}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}'
+
+# Set default server port (change if there is multiple Mork instances running)
+server:
+  port : 8080


### PR DESCRIPTION
Issue #75

> The current application.yml does not provide server properties.
> 
> server:
> port : PORT
> 
> https://www.baeldung.com/spring-boot-change-port
> 
> If an application uses 8080, MORK will fail asking to select another port, the user will have to type server: port: and the new port, if provided in the application.yml structure, it is easier to understand where to modify it.