### PR TITLE
Component param and VND refactor

### DIFF
--- a/common/src/main/java/es/urjc/etsii/grafo/annotations/ComponentParam.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/annotations/ComponentParam.java
@@ -1,0 +1,19 @@
+package es.urjc.etsii.grafo.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Declares how to generate values for a primitive parameter (int, double, etc) using the same strategies as Irace.
+ * See section 5.1.1 Parameter Types in the official irace manual for more details
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ComponentParam {
+
+    /**
+     * Disallowed classes for recursive components
+     * @return disallowe classes
+     */
+    Class<?>[] disallowed() default {};
+}

--- a/common/src/main/java/es/urjc/etsii/grafo/annotations/ComponentParam.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/annotations/ComponentParam.java
@@ -3,8 +3,7 @@ package es.urjc.etsii.grafo.annotations;
 import java.lang.annotation.*;
 
 /**
- * Declares how to generate values for a primitive parameter (int, double, etc) using the same strategies as Irace.
- * See section 5.1.1 Parameter Types in the official irace manual for more details
+ * Specifies additional restrictions when resolving algorithm components to available implementations
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
@@ -12,8 +11,8 @@ import java.lang.annotation.*;
 public @interface ComponentParam {
 
     /**
-     * Disallowed classes for recursive components
-     * @return disallowe classes
+     * Disallowed classes for recursive components. All derived classes from the disallowed list will be disallowed too.
+     * @return disallowed classes
      */
     Class<?>[] disallowed() default {};
 }

--- a/common/src/test/java/es/urjc/etsii/grafo/improve/VNDTest.java
+++ b/common/src/test/java/es/urjc/etsii/grafo/improve/VNDTest.java
@@ -1,0 +1,93 @@
+package es.urjc.etsii.grafo.improve;
+
+import es.urjc.etsii.grafo.algorithms.FMode;
+import es.urjc.etsii.grafo.testutil.TestInstance;
+import es.urjc.etsii.grafo.testutil.TestSolution;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class VNDTest {
+
+    Improver<TestSolution, TestInstance> improver1;
+    Improver<TestSolution, TestInstance> improver2;
+    Improver<TestSolution, TestInstance> improver3;
+
+    TestSolution solution;
+    TestInstance instance;
+
+    private FMode fmode;
+    private List<Integer> calls;
+    private List<Integer> expectedCallOrder = List.of(1,2,1,1,2,3,1,2,3);
+
+    @BeforeEach
+    void prepareMocks(){
+        calls = new ArrayList<>();
+        instance = new TestInstance("vndtest");
+        solution = new TestSolution(instance, 6);
+
+        // Improver 1 decreases by 1 if score ==5, improver 2 same but when 6, improver 3 decreases 1 if even
+        // Check that in VND, call order is
+        // I1 --> I2 --> I1 --> I1 --> I2 --> I3 --> I1 --> I2 --> I3 --> END
+
+        // If maximizing, order instead should be I1 --> I2 --> I3 --> END
+        this.improver1 = mock(Improver.class);
+        when(improver1.improve(any())).thenAnswer(a -> {
+            calls.add(1);
+            TestSolution s = a.getArgument(0);
+            if(s.getScore() == 5){
+                s.setScore(4);
+            } else if (s.getScore() == 7){
+                s.setScore(8);
+            }
+            return s;
+        });
+
+        this.improver2 = mock(Improver.class);
+        when(improver2.improve(any())).thenAnswer(a -> {
+            calls.add(2);
+            TestSolution s = a.getArgument(0);
+            if(s.getScore() == 6){
+                s.setScore(fmode == FMode.MINIMIZE? 5: 7);
+            }
+            return s;
+        });
+        this.improver3 = mock(Improver.class);
+        when(improver3.improve(any())).thenAnswer(a -> {
+            calls.add(3);
+            TestSolution s = a.getArgument(0);
+            if(s.getScore() % 2 == 0){
+                s.setScore(s.getScore() + (fmode == FMode.MINIMIZE? -1: +1));
+            }
+            return s;
+        });
+    }
+
+    @Test
+    void testVNDminimizing(){
+        fmode = FMode.MINIMIZE;
+        var vnd = new VND<>(FMode.MINIMIZE, improver1, improver2, improver3);
+        assertEquals(6, solution.getScore());
+        var improvedSolution = vnd.improve(solution);
+        assertEquals(3, improvedSolution.getScore());
+
+        assertEquals(expectedCallOrder, calls);
+    }
+
+    @Test
+    void testVNDmaximizing(){
+        fmode = FMode.MAXIMIZE;
+        var vnd = new VND<>(FMode.MAXIMIZE, improver1, improver2, improver3);
+        assertEquals(6, solution.getScore());
+        var improvedSolution = vnd.improve(solution);
+        assertEquals(9, improvedSolution.getScore());
+
+        assertEquals(expectedCallOrder, calls);
+    }
+}


### PR DESCRIPTION
When using autoconfig, algorithm components are automatically detected and resolved. Improve it by adding a new `@ComponentParam` annotation to allow users to specify restrictions, for example VND by default will not allow its internal improvers to be VNDs.

Refactor VND to use new DoubleComparator functions to avoid code duplication, and add unit tests for it @MLopez-Ibanez