### PR TITLE
Autoconfig improvement: Categorical and ordinal params now pick all v…

### DIFF
--- a/autoconfig/src/main/java/es/urjc/etsii/grafo/autoconfig/generator/AlgorithmCandidateGenerator.java
+++ b/autoconfig/src/main/java/es/urjc/etsii/grafo/autoconfig/generator/AlgorithmCandidateGenerator.java
@@ -205,7 +205,7 @@ public class AlgorithmCandidateGenerator {
     }
 
     private static void validateStringValues(Parameter p, String[] values) {
-        if (values.length == 0) {
+        if (values.length == 0 && !p.getType().isEnum()) {
             throw new IllegalArgumentException("Categorical and ordinal params must have at least one value. Found 0 values in %s".formatted(describe(p)));
         }
     }

--- a/autoconfig/src/main/java/es/urjc/etsii/grafo/autoconfig/irace/params/ComponentParameter.java
+++ b/autoconfig/src/main/java/es/urjc/etsii/grafo/autoconfig/irace/params/ComponentParameter.java
@@ -30,12 +30,12 @@ public class ComponentParameter {
     }
 
     public static ComponentParameter from(String name, Class<?> javaType, CategoricalParam p) {
-        var values = checkLength(p.strings());
+        var values = resolveStringValues(javaType, p.strings());
         return new ComponentParameter(name, javaType, CATEGORICAL, values);
     }
 
     public static ComponentParameter from(String name, Class<?> javaType, OrdinalParam p) {
-        var values = checkLength(p.strings());
+        var values = resolveStringValues(javaType, p.strings());
         return new ComponentParameter(name, javaType, ORDINAL, values);
     }
 
@@ -52,7 +52,7 @@ public class ComponentParameter {
     }
 
     public static ComponentParameter from(String name, Class<?> javaType, Collection<Class<?>> candidates) {
-        Class[] names = new Class[candidates.size()];
+        Class<?>[] names = new Class<?>[candidates.size()];
         var iterator = candidates.iterator();
         for (int i = 0; i < candidates.size(); i++) {
             names[i] = iterator.next();
@@ -65,6 +65,21 @@ public class ComponentParameter {
             throw new IllegalArgumentException("Categorical and ordinal params must have at least one value, 0 provided");
         }
         return values;
+    }
+
+    private static Object[] resolveStringValues(Class<?> javaType, String[] values) {
+        if (values.length > 0) {
+            return values;
+        }
+        if (!javaType.isEnum()) {
+            return checkLength(values);
+        }
+        var enumValues = javaType.getEnumConstants();
+        var enumNames = new String[enumValues.length];
+        for (int i = 0; i < enumValues.length; i++) {
+            enumNames[i] = ((Enum<?>) enumValues[i]).name();
+        }
+        return checkLength(enumNames);
     }
 
     public String getName() {

--- a/autoconfig/src/test/java/es/urjc/etsii/grafo/autoconfig/generator/AlgorithmCandidateGeneratorValidationTest.java
+++ b/autoconfig/src/test/java/es/urjc/etsii/grafo/autoconfig/generator/AlgorithmCandidateGeneratorValidationTest.java
@@ -1,7 +1,9 @@
 package es.urjc.etsii.grafo.autoconfig.generator;
 
+import es.urjc.etsii.grafo.annotations.CategoricalParam;
 import es.urjc.etsii.grafo.annotations.ComponentParam;
 import es.urjc.etsii.grafo.annotations.IntegerParam;
+import es.urjc.etsii.grafo.annotations.OrdinalParam;
 import es.urjc.etsii.grafo.annotations.RealParam;
 import es.urjc.etsii.grafo.autoconfig.inventory.AlgorithmInventoryService;
 import es.urjc.etsii.grafo.autoconfig.irace.params.ComponentParameter;
@@ -91,6 +93,56 @@ class AlgorithmCandidateGeneratorValidationTest {
         assertThrows(IllegalArgumentException.class, () -> generator.toComponentParameter(Map.of(), parameter));
     }
 
+    @Test
+    void categoricalParamInfersAllEnumValuesWhenEmpty() throws NoSuchMethodException {
+        var parameter = firstParameter(DefaultCategoricalEnumHolder.class);
+
+        ComponentParameter componentParameter = generator.toComponentParameter(Map.of(), parameter);
+
+        assertArrayEquals(new Object[]{"LOW", "MEDIUM", "HIGH"}, componentParameter.getValues());
+    }
+
+    @Test
+    void ordinalParamInfersAllEnumValuesWhenEmpty() throws NoSuchMethodException {
+        var parameter = firstParameter(DefaultOrdinalEnumHolder.class);
+
+        ComponentParameter componentParameter = generator.toComponentParameter(Map.of(), parameter);
+
+        assertArrayEquals(new Object[]{"LOW", "MEDIUM", "HIGH"}, componentParameter.getValues());
+    }
+
+    @Test
+    void explicitCategoricalEnumValuesArePreserved() throws NoSuchMethodException {
+        var parameter = firstParameter(ExplicitCategoricalEnumHolder.class);
+
+        ComponentParameter componentParameter = generator.toComponentParameter(Map.of(), parameter);
+
+        assertArrayEquals(new Object[]{"HIGH", "LOW"}, componentParameter.getValues());
+    }
+
+    @Test
+    void explicitOrdinalEnumOrderIsPreserved() throws NoSuchMethodException {
+        var parameter = firstParameter(ExplicitOrdinalEnumHolder.class);
+
+        ComponentParameter componentParameter = generator.toComponentParameter(Map.of(), parameter);
+
+        assertArrayEquals(new Object[]{"HIGH", "LOW"}, componentParameter.getValues());
+    }
+
+    @Test
+    void emptyCategoricalParamStillRejectsNonEnums() throws NoSuchMethodException {
+        var parameter = firstParameter(EmptyCategoricalStringHolder.class);
+
+        assertThrows(IllegalArgumentException.class, () -> generator.toComponentParameter(Map.of(), parameter));
+    }
+
+    @Test
+    void emptyOrdinalParamStillRejectsNonEnums() throws NoSuchMethodException {
+        var parameter = firstParameter(EmptyOrdinalBooleanHolder.class);
+
+        assertThrows(IllegalArgumentException.class, () -> generator.toComponentParameter(Map.of(), parameter));
+    }
+
     private static Parameter firstParameter(Class<?> clazz) throws NoSuchMethodException {
         return clazz.getConstructors()[0].getParameters()[0];
     }
@@ -127,6 +179,42 @@ class AlgorithmCandidateGeneratorValidationTest {
 
     public static class InvalidRealIntegerHolder {
         public InvalidRealIntegerHolder(@RealParam(min = 0, max = 1) int value) {
+        }
+    }
+
+    private enum TestLevel {
+        LOW,
+        MEDIUM,
+        HIGH
+    }
+
+    public static class DefaultCategoricalEnumHolder {
+        public DefaultCategoricalEnumHolder(@CategoricalParam TestLevel value) {
+        }
+    }
+
+    public static class DefaultOrdinalEnumHolder {
+        public DefaultOrdinalEnumHolder(@OrdinalParam TestLevel value) {
+        }
+    }
+
+    public static class ExplicitCategoricalEnumHolder {
+        public ExplicitCategoricalEnumHolder(@CategoricalParam(strings = {"HIGH", "LOW"}) TestLevel value) {
+        }
+    }
+
+    public static class ExplicitOrdinalEnumHolder {
+        public ExplicitOrdinalEnumHolder(@OrdinalParam(strings = {"HIGH", "LOW"}) TestLevel value) {
+        }
+    }
+
+    public static class EmptyCategoricalStringHolder {
+        public EmptyCategoricalStringHolder(@CategoricalParam String value) {
+        }
+    }
+
+    public static class EmptyOrdinalBooleanHolder {
+        public EmptyOrdinalBooleanHolder(@OrdinalParam boolean value) {
         }
     }
 

--- a/common/src/main/java/es/urjc/etsii/grafo/annotations/CategoricalParam.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/annotations/CategoricalParam.java
@@ -6,7 +6,7 @@ import java.lang.annotation.*;
  * Declares a categorical tunable parameter using the same categorical parameter type as irace.
  * Values are provided as strings and converted at runtime to the constructor parameter type when possible
  * (for example String, boolean, enum, numeric values, or objectives by name).
- * At least one value must be provided.
+ * At least one value must be provided, except for enum parameters where omitting values uses all enum constants.
  * See section 5.1.1 Parameter Types in the official irace manual for more details.
  */
 @Target(ElementType.PARAMETER)
@@ -15,7 +15,7 @@ import java.lang.annotation.*;
 public @interface CategoricalParam {
     /**
      * Candidate values for this parameter.
-     * @return non-empty list of categorical values
+     * @return list of categorical values, or empty to use all enum constants if parameter is an enum
      */
     String[] strings() default {};
 }

--- a/common/src/main/java/es/urjc/etsii/grafo/annotations/OrdinalParam.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/annotations/OrdinalParam.java
@@ -5,7 +5,8 @@ import java.lang.annotation.*;
 /**
  * Declares an ordinal tunable parameter using the same ordinal parameter type as irace.
  * Values are provided as strings and converted at runtime to the constructor parameter type when possible.
- * At least one value must be provided, ordered from lowest to highest according to the domain.
+ * At least one value must be provided, ordered from lowest to highest according to the domain, except for enum
+ * parameters where omitting values uses all enum constants in declaration order.
  * See section 5.1.1 Parameter Types in the official irace manual for more details.
  */
 @Target(ElementType.PARAMETER)
@@ -14,7 +15,7 @@ import java.lang.annotation.*;
 public @interface OrdinalParam {
     /**
      * Ordered candidate values for this parameter.
-     * @return non-empty list of ordinal values
+     * @return ordered list of ordinal values, or empty to use all enum constants in declaration order if parameter is an enum
      */
     String[] strings() default {};
 }


### PR DESCRIPTION
…alues if none are explicitly provided and target type is an enum.